### PR TITLE
Use relative path over subdomain for keybase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN printf "[multilib]\n"\
 "Include=/etc/pacman.d/mirrorlist\n"\
 "[mobile]\n"\
 "SigLevel = Never\n"\
-'Server=https://farwayer.keybase.pub/arch/$repo' >> /etc/pacman.conf
+'Server=https://keybase.pub/farwayer/arch/$repo' >> /etc/pacman.conf
 RUN pacman --noconfirm -Sy yarn npm watchman jdk8-openjdk git\
  fastlane python2 make gcc\
  android-platform\


### PR DESCRIPTION
It seems keybase suddenly doesn't support subdomains anymore, this should fix it!

(Thank you for this excellent image, btw)!~