### PR TITLE
Use archlinux/base as parent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM archlinux/base
-MAINTAINER farwayer <farwayer@gmail.com>
+LABEL description="Environment for building React Native apps for Android"
+LABEL maintainer="Tuomas Jaakola <tuomas.jaakola@iki.fi>"
 
 # Make pacman to use wget for more reliable downloads
 RUN pacman --noconfirm -Sy wget
@@ -10,28 +11,18 @@ RUN printf "[multilib]\n"\
 "[mobile]\n"\
 "SigLevel = Never\n"\
 'Server=https://farwayer.keybase.pub/arch/$repo' >> /etc/pacman.conf
+
+# Install packages
+# android-sdk-build-tools should come with android-platform pkg
 RUN pacman --noconfirm --disable-download-timeout -Sy\
  yarn npm watchman jdk8-openjdk git procps-ng\
- fastlane python2 make gcc\
- android-platform-23\
- android-platform-24\
- android-platform-25\
- android-platform-26\
- android-platform-27\
- android-platform-28\
- android-sdk-build-tools-23.0.1\
- android-sdk-build-tools-23.0.3\
- android-sdk-build-tools-25\
- android-sdk-build-tools-25.0.2\
- android-sdk-build-tools-25.0.3\
- android-sdk-build-tools-26.0.1\
- android-sdk-build-tools-26.0.2\
- android-sdk-build-tools-26.0.3\
- android-sdk-build-tools-27.0.3\
- android-sdk-build-tools-28.0.2\
- android-sdk-build-tools-28.0.3\
+ python2 make gcc\
+ android-platform-29\
  android-google-repository\
  android-support-repository\
  && yes | pacman -Scc || true\
  && rm -rf /usr/lib/ruby/gems/*/{cache,doc} /usr/share/{doc,man,locale}
 ENV ANDROID_HOME=/opt/android-sdk
+
+# Accepting all Android SDK package licenses is required
+RUN yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pritunl/archlinux
+FROM archlinux/base
 MAINTAINER farwayer <farwayer@gmail.com>
 
 RUN printf "[multilib]\n"\

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN printf "[multilib]\n"\
 "[mobile]\n"\
 "SigLevel = Never\n"\
 'Server=https://farwayer.keybase.pub/arch/$repo' >> /etc/pacman.conf
-RUN pacman --noconfirm -Sy yarn npm watchman jdk8-openjdk git\
+RUN pacman --noconfirm --disable-download-timeout -Sy\
+ yarn npm watchman jdk8-openjdk git\
  fastlane python2 make gcc\
  android-platform-23\
  android-platform-24\

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN pacman --noconfirm -Sy yarn npm watchman jdk8-openjdk git\
  android-sdk-build-tools-26.0.3\
  android-sdk-build-tools-27.0.3\
  android-sdk-build-tools-28.0.2\
+ android-sdk-build-tools-28.0.3\
  android-google-repository\
  android-support-repository\
  && yes | pacman -Scc\

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN printf "[multilib]\n"\
 "SigLevel = Never\n"\
 'Server=https://farwayer.keybase.pub/arch/$repo' >> /etc/pacman.conf
 RUN pacman --noconfirm --disable-download-timeout -Sy\
- yarn npm watchman jdk8-openjdk git\
+ yarn npm watchman jdk8-openjdk git procps-ng\
  fastlane python2 make gcc\
  android-platform-23\
  android-platform-24\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM archlinux/base
 MAINTAINER farwayer <farwayer@gmail.com>
 
+# Make pacman to use wget for more reliable downloads
+RUN pacman --noconfirm -Sy wget
+RUN sed -i 's/#VerbosePkgLists/XferCommand = \/usr\/bin\/wget -nv -c -O %o %u/g' /etc/pacman.conf
+
 RUN printf "[multilib]\n"\
 "Include=/etc/pacman.d/mirrorlist\n"\
 "[mobile]\n"\
@@ -28,7 +32,7 @@ RUN pacman --noconfirm --disable-download-timeout -Sy\
  android-sdk-build-tools-28.0.3\
  android-google-repository\
  android-support-repository\
- && yes | pacman -Scc\
+ && yes | pacman -Scc || true\
  && rm -rf /usr/lib/ruby/gems/*/{cache,doc} /usr/share/{doc,man,locale}\
  && mkdir /var/run/watchman
 ENV ANDROID_HOME=/opt/android-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,5 @@ RUN pacman --noconfirm --disable-download-timeout -Sy\
  android-google-repository\
  android-support-repository\
  && yes | pacman -Scc || true\
- && rm -rf /usr/lib/ruby/gems/*/{cache,doc} /usr/share/{doc,man,locale}\
- && mkdir /var/run/watchman
+ && rm -rf /usr/lib/ruby/gems/*/{cache,doc} /usr/share/{doc,man,locale}
 ENV ANDROID_HOME=/opt/android-sdk

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ All package versions are recent for building date.
 - **26.0.3**
 - **27.0.3**  
 - **28.0.2**  
+- **28.0.3**
 
 You can install extra sdk build tools with pacman:
 ```bash


### PR DESCRIPTION
pritunl/archlinux is no longer maintained so changing the base image.

Pacman got random errors when downloading packages from https://farwayer.keybase.pub/. Changing pacman to use wget as downloader fixed that problem.

Also latest Android SDK Build Tools 28.0.3 added.

Fixes #3 